### PR TITLE
Fixed internal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,10 @@
+1.0.1
+=====
+
+*   Fixed internal types in the `Router`.
+
+
 1.0.0
 =====
+
+Initial release `\o/`

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ function stringifyValue (value: string|number|boolean|null|undefined, explicitFa
 /**
  * Generates the query string
  */
-function generateQuery (variables: string[], parameters: RouteParameters) : string|null
+function generateQuery (variables: string[], parameters: RouteParameters) : string
 {
     // use all parameters as default
     let surplus = parameters;
@@ -182,7 +182,7 @@ export class Router
         try
         {
             let host = compileTokens(route.host, parameters);
-            let segments = [];
+            let segments: string[] = [];
             let isMissingRequiredScheme = route.schemes.length > 0 && -1 === route.schemes.indexOf(this.context.scheme);
             let includeScheme = false;
             let scheme = isMissingRequiredScheme


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | yes                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | not needed <!-- insert URL here -->                                  |

<!-- describe your changes below -->
By default, the inferred type of `[]` in TypeScript is `never[]`, because that's useful to anyone. 